### PR TITLE
Update st_timer on aura gain/loss

### DIFF
--- a/SP_SwingTimer.lua
+++ b/SP_SwingTimer.lua
@@ -177,6 +177,7 @@ function SP_ST_OnLoad()
 	this:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES")
 	this:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_SELF_BUFFS")
 	this:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_SELF")
+	this:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE")
 end
 
 function SP_ST_OnEvent()
@@ -232,19 +233,11 @@ function SP_ST_OnEvent()
 			end
 		end
 
-	elseif (event == "CHAT_MSG_SPELL_PERIODIC_SELF_BUFFS") then
+	-- Here we check at every aura gain/loss if the weaponspeed is changed, if it is we modify the timer acordingly 
+	elseif (event == "CHAT_MSG_SPELL_PERIODIC_SELF_BUFFS") or (event == "CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE") or (event == "CHAT_MSG_SPELL_AURA_GONE_SELF") then
 		if (prevWepSpeed ~= nil) then
-			if (string.find(arg1, "Flurry")) then
-				local newSpeed = GetWeaponSpeed();
-				local perc = st_timer / prevWepSpeed;
-				st_timer = newSpeed * perc;
-			end
-		end
-
-	elseif (event == "CHAT_MSG_SPELL_AURA_GONE_SELF") then
-		if (prevWepSpeed ~= nil) then
-			if (string.find(arg1, "Flurry")) then
-				local newSpeed = GetWeaponSpeed();
+			local newSpeed = GetWeaponSpeed();
+			if (prevWepSpeed ~= newSpeed) then
 				local perc = st_timer / prevWepSpeed;
 				st_timer = newSpeed * perc;
 			end

--- a/SP_SwingTimer.lua
+++ b/SP_SwingTimer.lua
@@ -1,5 +1,5 @@
 
-local version = "3.0.1"
+local version = "3.1.0"
 
 local defaults = {
 	x = 0,
@@ -52,6 +52,7 @@ end
 
 local weapon = nil
 local combat = false
+local prevWepSpeed = nil;
 st_timer = 0.0
 
 --------------------------------------------------------------------------------
@@ -127,6 +128,7 @@ local function UpdateWeapon()
 	weapon = GetInventoryItemLink("player", GetInventorySlotInfo("MainHandSlot"))
 end
 local function ResetTimer()
+	prevWepSpeed = GetWeaponSpeed();
 	st_timer = GetWeaponSpeed()
 	SP_ST_Frame:Show()
 end
@@ -173,6 +175,8 @@ function SP_ST_OnLoad()
 	this:RegisterEvent("CHAT_MSG_COMBAT_SELF_HITS")
 	this:RegisterEvent("CHAT_MSG_SPELL_SELF_DAMAGE")
 	this:RegisterEvent("CHAT_MSG_COMBAT_CREATURE_VS_SELF_MISSES")
+	this:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_SELF_BUFFS")
+	this:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_SELF")
 end
 
 function SP_ST_OnEvent()
@@ -225,6 +229,24 @@ function SP_ST_OnEvent()
 			if spell and combatSpells[spell] then
 				ResetTimer()
 				break
+			end
+		end
+
+	elseif (event == "CHAT_MSG_SPELL_PERIODIC_SELF_BUFFS") then
+		if (prevWepSpeed ~= nil) then
+			if (string.find(arg1, "Flurry")) then
+				local newSpeed = GetWeaponSpeed();
+				local perc = st_timer / prevWepSpeed;
+				st_timer = newSpeed * perc;
+			end
+		end
+
+	elseif (event == "CHAT_MSG_SPELL_AURA_GONE_SELF") then
+		if (prevWepSpeed ~= nil) then
+			if (string.find(arg1, "Flurry")) then
+				local newSpeed = GetWeaponSpeed();
+				local perc = st_timer / prevWepSpeed;
+				st_timer = newSpeed * perc;
 			end
 		end
 

--- a/SP_SwingTimer.toc
+++ b/SP_SwingTimer.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: SP_|cffa050ffSwingTimer|r
 ## Author: https://github.com/EinBaum
-## Version: 3.0.1
+## Version: 3.1.0
 ## Notes: Auto-Attack Swing Timer. Chat command: |cffa050ff/st|r
 ## Dependencies:
 ## OptionalDeps:


### PR DESCRIPTION
This modification check for aura gain/loss that modify attack and update the timer accordingly so it does not go out of sync


This part of solves https://github.com/EinBaum/SP_SwingTimer/issues/8